### PR TITLE
feat: Интеграция функционала "Youtube Remember Speed"

### DIFF
--- a/ReTube.user.js
+++ b/ReTube.user.js
@@ -2,7 +2,7 @@
 // @name         ReTube
 // @namespace 	http://tampermonkey.net/
 // @version      4.5.5
-// @description ReTube - Merged with Youtube Remember Speed
+// @description ReTube
 // @author       Eject
 // @match        *://www.youtube.com/*
 // @match        *://music.youtube.com/*


### PR DESCRIPTION
Этот Pull Request добавляет в ReTube функциональность для запоминания и автоматической установки предпочитаемой скорости воспроизведения видео, интегрируя логику из популярного userscript-а "Youtube Remember Speed". Это избавляет пользователей от необходимости устанавливать скорость вручную для каждого видео.

**Основные изменения:**

1.  **Новая опция в меню ReTube (F2):**
    *   На вкладке "Другие" добавлена опция **"Запомнить скорость воспроизведения"**.
    *   Рядом с ней находится выпадающий список (`<select>`), позволяющий выбрать желаемую скорость.
    *   Добавлен чекбокс **"Обход нативного контроллера"**, который активирует режим с более точной настройкой скорости (например, `1.125x`, `1.375x`), аналогично оригинальному скрипту.

2.  **Реализация:**
    *   Основная логика вынесена в новую функцию `RememberSpeed()`, которая вызывается при загрузке видео (`loadeddata`).
    *   Добавлены новые переменные для хранения настроек: `RTRememberSpeed`, `RTSelectRememberSpeedLevel`, `RTRememberSpeedBypass`.
    *   Настройки сохраняются и загружаются через `GM_setValue` / `GM_getValue`, полностью интегрируясь в существующую систему конфигурации ReTube.
    *   Интерфейс настроек динамически обновляет список доступных скоростей в зависимости от состояния чекбокса "Обход нативного контроллера".
    *   Функциональность корректно работает при переходе между страницами (yt-navigate-finish).

3.  **Преимущества:**
    *   Расширяет возможности ReTube, добавляя востребованную функцию.
    *   Позволяет пользователям отказаться от отдельного скрипта для управления скоростью.
    *   Полностью интегрировано в существующий UI и логику ReTube для удобства использования.

Этот PR успешно объединяет два полезных инструмента в один, делая ReTube еще более мощным и удобным.